### PR TITLE
把ProgressBar贴到底部

### DIFF
--- a/app/src/main/res/layout/fragment_list_videos.xml
+++ b/app/src/main/res/layout/fragment_list_videos.xml
@@ -28,7 +28,8 @@
                 android:layout_gravity="bottom"
                 android:indeterminate="true"
                 app:mpb_progressStyle="horizontal"
-                style="@style/Widget.MaterialProgressBar.ProgressBar.Horizontal"
+                app:mpb_useIntrinsicPadding="false"
+                style="@style/Widget.MaterialProgressBar.ProgressBar.Horizontal.NoPadding"
                 android:visibility="gone"
                 />
 


### PR DESCRIPTION
参考了MaterialProgressBar的示例中的代码：
https://github.com/DreaminginCodeZH/MaterialProgressBar/blob/76425b5a7dba2ad86ce8640ef7d93c4d95949a23/sample/src/main/res/layout/main_activity.xml#L249

不过我没加`app:mpb_showTrack="false"`，你可以试一下效果，根据你的喜欢选择加不加这个。