### PR TITLE
消除视频详情页中预览图两边的橘色线条

### DIFF
--- a/app/src/main/java/com/optimalorange/cooltechnologies/ui/ShowVideoDetailActivity.java
+++ b/app/src/main/java/com/optimalorange/cooltechnologies/ui/ShowVideoDetailActivity.java
@@ -82,7 +82,18 @@ public class ShowVideoDetailActivity extends LoginableBaseActivity {
             final ImageLoader.ImageListener imageListener = ImageLoader.getImageListener(
                     mViews.thumbnail, 0, 0
             );
-            mVolleySingleton.getImageLoader().get(video.thumbnail, imageListener);
+            final ImageLoader.ImageListener imageListenerWrapper = new ImageLoader.ImageListener() {
+                @Override
+                public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
+                    imageListener.onResponse(response, isImmediate);
+                    mViews.thumbnail.setBackgroundResource(R.color.black);
+                }
+                @Override
+                public void onErrorResponse(VolleyError error) {
+                    imageListener.onErrorResponse(error);
+                }
+            };
+            mVolleySingleton.getImageLoader().get(video.thumbnail, imageListenerWrapper);
         }
     }
 


### PR DESCRIPTION
新增 视频详情页显示预览图时，设置其背景为黑色，以消除两边的橘色（?attr/colorPrimary）线条