### PR TITLE
更新Android Gradle Build插件

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,10 +2,11 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
+        classpath 'com.android.tools.build:gradle:2.0.0-alpha1'
+        classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
修改 更新Android Gradle Build插件
修改 暂时通过[jitpack.io](https://jitpack.io)，使用最新版android-sdk-manager Gradle插件，以兼容新版Android Gradle Build插件