### PR TITLE
用更好的方式实现“消除视频详情页中预览图两边的橘色线条”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - 修复“仅在WLAN下，播放视频”设置失效的问题
+- 避免视频详情页加载缩略图时，先闪过全黑图的问题
+- 修复进入并马上退出视频详情页时，程序崩溃的问题
 
 ## [1.1.0] - 2015-12-03
 ### Changed

--- a/app/src/main/java/com/optimalorange/cooltechnologies/ui/ShowVideoDetailActivity.java
+++ b/app/src/main/java/com/optimalorange/cooltechnologies/ui/ShowVideoDetailActivity.java
@@ -87,19 +87,7 @@ public class ShowVideoDetailActivity extends LoginableBaseActivity {
             final ImageLoader.ImageListener imageListener = ImageLoader.getImageListener(
                     mViews.thumbnail, 0, 0
             );
-            final ImageLoader.ImageListener imageListenerWrapper = new ImageLoader.ImageListener() {
-                @Override
-                public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
-                    imageListener.onResponse(response, isImmediate);
-                    mViews.thumbnail.setBackgroundResource(R.color.black);
-                }
-
-                @Override
-                public void onErrorResponse(VolleyError error) {
-                    imageListener.onErrorResponse(error);
-                }
-            };
-            mVolleySingleton.getImageLoader().get(video.thumbnail, imageListenerWrapper);
+            mVolleySingleton.getImageLoader().get(video.thumbnail, imageListener);
         }
     }
 

--- a/app/src/main/res/layout/activity_show_video_detail.xml
+++ b/app/src/main/res/layout/activity_show_video_detail.xml
@@ -33,6 +33,7 @@
                         android:id="@+id/app_bar_image"
                         app:layout_widthPercent="100%"
                         app:layout_aspectRatio="178%"
+                        android:scaleType="fitXY"
                         />
             </android.support.percent.PercentFrameLayout>
 


### PR DESCRIPTION
相关pull request：
#64